### PR TITLE
Corrigido o tipo do campo da imagem de um evento

### DIFF
--- a/app/src/main/java/com/infact/nightour/BancoDeDados.java
+++ b/app/src/main/java/com/infact/nightour/BancoDeDados.java
@@ -25,7 +25,7 @@ public class BancoDeDados extends SQLiteOpenHelper {
                 + Evento.BD_NOME + " text, "
                 + Evento.BD_DESCRICAO + " text, "
                 + Evento.BD_GENERO + " text, "
-                + Evento.BD_IMAGEM + " text "
+                + Evento.BD_IMAGEM + " blob "
                 + " ) ";
 
         db.execSQL(query);


### PR DESCRIPTION
O tipo estava como "text", quando uma imagem na verdade precisa ser um "blob" no banco de dados.